### PR TITLE
feat: add versioning for genesis generation

### DIFF
--- a/cmd/network.go
+++ b/cmd/network.go
@@ -129,6 +129,7 @@ validators launch their nodes, a blockchain will be live.
 		NewNetworkProfile(),
 		NewNetworkCoordinator(),
 		NewNetworkTool(),
+		NewNetworkVersion(),
 	)
 
 	return c

--- a/cmd/network_chain_prepare.go
+++ b/cmd/network_chain_prepare.go
@@ -95,7 +95,7 @@ func networkChainPrepareHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if !force && chainLaunch.Metadata.Cli.Version != "" && chainLaunch.Metadata.Cli.Version != networktypes.Version {
+	if !force && chainLaunch.Metadata.Cli.Version != "" && !chainLaunch.Metadata.IsCurrentVersion() {
 		return fmt.Errorf(`chain %d has been published with a different version of the plugin (%s, current version is %s)
 this may result in a genesis that is different from other validators' genesis
 use --force to prepare anyway`,

--- a/cmd/network_chain_prepare.go
+++ b/cmd/network_chain_prepare.go
@@ -95,6 +95,16 @@ func networkChainPrepareHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if !force && chainLaunch.Metadata.Cli.Version != "" && chainLaunch.Metadata.Cli.Version != networktypes.Version {
+		return fmt.Errorf(`chain %d has been published with a different version of the plugin (%s, current version is %s)
+this may result in a genesis that is different from other validators' genesis
+use --force to prepare anyway`,
+			launchID,
+			chainLaunch.Metadata.Cli.Version,
+			networktypes.Version,
+		)
+	}
+
 	if !force && !chainLaunch.LaunchTriggered {
 		return fmt.Errorf("chain %d launch has not been triggered yet. use --force to prepare anyway", launchID)
 	}

--- a/cmd/network_chain_publish.go
+++ b/cmd/network_chain_publish.go
@@ -86,7 +86,7 @@ the "--account-balance" flag with a list of coins.
 	c.Flags().String(flagChainID, "", "chain ID to use for this network")
 	c.Flags().Uint64(flagProject, 0, "project ID to use for this network")
 	c.Flags().Bool(flagNoCheck, false, "skip verifying chain's integrity")
-	c.Flags().String(flagProjectMetadata, "", "add a project metadata")
+	c.Flags().String(flagMetadata, "", "add chain metadata")
 	c.Flags().String(flagProjectTotalSupply, "", "add a total of the mainnet of a project")
 	c.Flags().String(flagShares, "", "add shares for the project")
 	c.Flags().Bool(flagMainnet, false, "initialize a mainnet project")
@@ -117,7 +117,7 @@ func networkChainPublishHandler(cmd *cobra.Command, args []string) error {
 		chainID, _               = cmd.Flags().GetString(flagChainID)
 		project, _               = cmd.Flags().GetUint64(flagProject)
 		noCheck, _               = cmd.Flags().GetBool(flagNoCheck)
-		projectMetadata, _       = cmd.Flags().GetString(flagProjectMetadata)
+		metadata, _              = cmd.Flags().GetString(flagMetadata)
 		projectTotalSupplyStr, _ = cmd.Flags().GetString(flagProjectTotalSupply)
 		sharesStr, _             = cmd.Flags().GetString(flagShares)
 		isMainnet, _             = cmd.Flags().GetBool(flagMainnet)
@@ -237,7 +237,7 @@ func networkChainPublishHandler(cmd *cobra.Command, args []string) error {
 	initOptions = append(initOptions, networkchain.WithHome(homeDir))
 
 	// prepare publish options
-	publishOptions := []network.PublishOption{network.WithMetadata(projectMetadata)}
+	publishOptions := []network.PublishOption{network.WithMetadata(metadata)}
 
 	switch {
 	case genesisURL != "":

--- a/cmd/network_chain_show_genesis.go
+++ b/cmd/network_chain_show_genesis.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ignite/cli-plugin-network/network/networkchain"
+	"github.com/ignite/cli-plugin-network/network/networktypes"
 )
 
 func newNetworkChainShowGenesis() *cobra.Command {
@@ -93,6 +94,16 @@ func networkChainShowGenesisHandler(cmd *cobra.Command, args []string) error {
 
 	if err := xos.Rename(genesisPath, out); err != nil {
 		return err
+	}
+
+	if chainLaunch.Metadata.Cli.Version != "" && chainLaunch.Metadata.Cli.Version != networktypes.Version {
+		session.Printf(`⚠️chain %d has been published with a different version of the plugin (%s, current version is %s)
+this may result in a genesis that is different from other validators' genesis
+for chain launch, please update the plugin to the same version`,
+			launchID,
+			chainLaunch.Metadata.Cli.Version,
+			networktypes.Version,
+		)
 	}
 
 	return session.Printf("%s Genesis generated: %s\n", icons.Bullet, out)

--- a/cmd/network_chain_show_genesis.go
+++ b/cmd/network_chain_show_genesis.go
@@ -97,9 +97,9 @@ func networkChainShowGenesisHandler(cmd *cobra.Command, args []string) error {
 	}
 
 	if chainLaunch.Metadata.Cli.Version != "" && chainLaunch.Metadata.Cli.Version != networktypes.Version {
-		session.Printf(`⚠️chain %d has been published with a different version of the plugin (%s, current version is %s)
+		session.Printf(`⚠️ chain %d has been published with a different version of the plugin (%s, current version is %s)
 this may result in a genesis that is different from other validators' genesis
-for chain launch, please update the plugin to the same version`,
+for chain launch, please update the plugin to the same version\n`,
 			launchID,
 			chainLaunch.Metadata.Cli.Version,
 			networktypes.Version,

--- a/cmd/network_chain_show_genesis.go
+++ b/cmd/network_chain_show_genesis.go
@@ -96,7 +96,7 @@ func networkChainShowGenesisHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if chainLaunch.Metadata.Cli.Version != "" && chainLaunch.Metadata.Cli.Version != networktypes.Version {
+	if chainLaunch.Metadata.Cli.Version != "" && !chainLaunch.Metadata.IsCurrentVersion() {
 		session.Printf(`⚠️ chain %d has been published with a different version of the plugin (%s, current version is %s)
 this may result in a genesis that is different from other validators' genesis
 for chain launch, please update the plugin to the same version\n`,

--- a/cmd/network_version.go
+++ b/cmd/network_version.go
@@ -4,7 +4,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ignite/cli/ignite/pkg/cliui"
-	"github.com/ignite/cli/ignite/pkg/cliui/icons"
 
 	"github.com/ignite/cli-plugin-network/network/networktypes"
 )
@@ -27,5 +26,5 @@ func networkVersion(_ *cobra.Command, _ []string) error {
 	session := cliui.New(cliui.StartSpinner())
 	defer session.End()
 
-	return session.Printf("%s%s\n", icons.OK, networktypes.Version)
+	return session.Printf("%s\n", networktypes.Version)
 }

--- a/cmd/network_version.go
+++ b/cmd/network_version.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/ignite/cli/ignite/pkg/cliui"
+	"github.com/ignite/cli/ignite/pkg/cliui/icons"
+
+	"github.com/ignite/cli-plugin-network/network/networktypes"
+)
+
+// NewNetworkVersion creates a new version command to get the version of the plugin
+// The version of the plugin to use to interact with a chain might be specified by the coordinator
+func NewNetworkVersion() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "version",
+		Short: "Version of the plugin",
+		Long: `The version of the plugin to use to interact with a chain might be specified by the coordinator.
+`,
+		RunE: networkVersion,
+		Args: cobra.NoArgs,
+	}
+	return c
+}
+
+func networkVersion(_ *cobra.Command, _ []string) error {
+	session := cliui.New(cliui.StartSpinner())
+	defer session.End()
+
+	return session.Printf("%s%s\n", icons.OK, networktypes.Version)
+}

--- a/network/networktypes/chainlaunch.go
+++ b/network/networktypes/chainlaunch.go
@@ -27,7 +27,7 @@ type (
 		Network                NetworkType `json:"Network"`
 		Reward                 string      `json:"Reward,omitempty"`
 		AccountBalance         sdk.Coins   `json:"AccountBalance"`
-		Metadata               interface{} `json:"Metadata"`
+		Metadata               Metadata    `json:"Metadata"`
 	}
 )
 
@@ -69,7 +69,7 @@ func ToChainLaunch(chain launchtypes.Chain) ChainLaunch {
 	if err != nil {
 		// an error shouldn't happen
 		// in case it occurs, we consider metadata as invalid and dismiss those
-		launch.Metadata = nil
+		launch.Metadata = Metadata{}
 	}
 
 	// check if custom genesis URL is provided.

--- a/network/networktypes/metadata.go
+++ b/network/networktypes/metadata.go
@@ -1,7 +1,7 @@
 package networktypes
 
 // Current version of the network plugin
-const Version = "0.1.0"
+const Version = "1"
 
 // Cli holds information about the CLI used to interact with the chain
 type Cli struct {

--- a/network/networktypes/metadata.go
+++ b/network/networktypes/metadata.go
@@ -1,0 +1,21 @@
+package networktypes
+
+// Current version of the network plugin
+const Version = "0.1.0"
+
+// Cli holds information about the CLI used to interact with the chain
+type Cli struct {
+	Version string `json:"version"`
+}
+
+// Metadata is an object that contains the metadata of a chain
+// the metadata represents generic data set by the coordinator
+// these information can be formatted and interpreted by the CLI for specific purposes
+type Metadata struct {
+	Cli Cli `json:"cli"`
+}
+
+// IsVersionEqual checks if the version of the CLI is equal with one from the metadata
+func (m Metadata) IsVersionEqual(version string) bool {
+	return m.Cli.Version == version
+}

--- a/network/networktypes/metadata.go
+++ b/network/networktypes/metadata.go
@@ -15,7 +15,7 @@ type Metadata struct {
 	Cli Cli `json:"cli"`
 }
 
-// IsVersionEqual checks if the version of the CLI is equal with one from the metadata
-func (m Metadata) IsVersionEqual(version string) bool {
-	return m.Cli.Version == version
+// IsCurrentVersion checks if the version of the CLI is equal to the current version
+func (m Metadata) IsCurrentVersion() bool {
+	return m.Cli.Version == Version
 }

--- a/network/networktypes/metadata_test.go
+++ b/network/networktypes/metadata_test.go
@@ -1,0 +1,41 @@
+package networktypes_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ignite/cli-plugin-network/network/networktypes"
+)
+
+func TestMetadata_IsCurrentVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		m    networktypes.Metadata
+		want bool
+	}{
+		{
+			name: "current version",
+			m: networktypes.Metadata{
+				Cli: networktypes.Cli{
+					Version: networktypes.Version,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "not current version",
+			m: networktypes.Metadata{
+				Cli: networktypes.Cli{
+					Version: "0",
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.m.IsCurrentVersion())
+		})
+	}
+}

--- a/network/publish_test.go
+++ b/network/publish_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/ignite/cli-plugin-network/network/testutil"
 )
 
+var metadata = []byte("{\"cli\":{\"version\":\"1\"}}")
+
 func startGenesisTestServer(filepath string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		file, err := os.ReadFile(filepath)
@@ -76,6 +78,7 @@ func TestPublish(t *testing.T) {
 					InitialGenesis: launchtypes.NewDefaultInitialGenesis(),
 					HasCampaign:    false,
 					CampaignID:     0,
+					Metadata:       metadata,
 				},
 			).
 			Return(testutil.NewResponse(&launchtypes.MsgCreateChainResponse{
@@ -135,6 +138,7 @@ func TestPublish(t *testing.T) {
 					HasCampaign:    false,
 					CampaignID:     0,
 					AccountBalance: accountBalance,
+					Metadata:       metadata,
 				},
 			).
 			Return(testutil.NewResponse(&launchtypes.MsgCreateChainResponse{
@@ -204,6 +208,7 @@ func TestPublish(t *testing.T) {
 					InitialGenesis: launchtypes.NewDefaultInitialGenesis(),
 					HasCampaign:    true,
 					CampaignID:     testutil.ProjectID,
+					Metadata:       metadata,
 				},
 			).
 			Return(testutil.NewResponse(&launchtypes.MsgCreateChainResponse{
@@ -292,6 +297,7 @@ func TestPublish(t *testing.T) {
 					InitialGenesis: launchtypes.NewDefaultInitialGenesis(),
 					HasCampaign:    true,
 					CampaignID:     testutil.ProjectID,
+					Metadata:       metadata,
 				},
 			).
 			Return(testutil.NewResponse(&launchtypes.MsgCreateChainResponse{
@@ -359,6 +365,7 @@ func TestPublish(t *testing.T) {
 					),
 					HasCampaign: false,
 					CampaignID:  0,
+					Metadata:    []byte("{\"cli\":{\"version\":\"1\"}}"),
 				},
 			).
 			Return(testutil.NewResponse(&launchtypes.MsgCreateChainResponse{
@@ -417,6 +424,7 @@ func TestPublish(t *testing.T) {
 					InitialGenesis: launchtypes.NewDefaultInitialGenesis(),
 					HasCampaign:    false,
 					CampaignID:     0,
+					Metadata:       metadata,
 				},
 			).
 			Return(testutil.NewResponse(&launchtypes.MsgCreateChainResponse{
@@ -473,6 +481,7 @@ func TestPublish(t *testing.T) {
 					),
 					HasCampaign: false,
 					CampaignID:  0,
+					Metadata:    []byte("{\"cli\":{\"version\":\"1\"}}"),
 				},
 			).
 			Return(testutil.NewResponse(&launchtypes.MsgCreateChainResponse{
@@ -532,6 +541,7 @@ func TestPublish(t *testing.T) {
 					InitialGenesis: launchtypes.NewDefaultInitialGenesis(),
 					HasCampaign:    false,
 					CampaignID:     0,
+					Metadata:       metadata,
 				},
 			).
 			Return(testutil.NewResponse(&launchtypes.MsgCreateChainResponse{
@@ -735,6 +745,7 @@ func TestPublish(t *testing.T) {
 					InitialGenesis: launchtypes.NewDefaultInitialGenesis(),
 					HasCampaign:    false,
 					CampaignID:     0,
+					Metadata:       metadata,
 				},
 			).
 			Return(testutil.NewResponse(&launchtypes.MsgCreateChainResponse{
@@ -882,6 +893,7 @@ func TestPublish(t *testing.T) {
 					InitialGenesis: launchtypes.NewDefaultInitialGenesis(),
 					HasCampaign:    false,
 					CampaignID:     0,
+					Metadata:       metadata,
 				},
 			).
 			Return(testutil.NewResponse(&launchtypes.MsgCreateChainResponse{
@@ -936,6 +948,7 @@ func TestPublish(t *testing.T) {
 					InitialGenesis: launchtypes.NewDefaultInitialGenesis(),
 					HasCampaign:    false,
 					CampaignID:     0,
+					Metadata:       metadata,
 				},
 			).
 			Return(testutil.NewResponse(&launchtypes.MsgCreateChainResponse{

--- a/network/publish_test.go
+++ b/network/publish_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/ignite/cli-plugin-network/network/testutil"
 )
 
-var metadata = []byte("{\"cli\":{\"version\":\"1\"}}")
+var metadata = []byte(`{"cli":{"version":"1"}}`)
 
 func startGenesisTestServer(filepath string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/network/publish_test.go
+++ b/network/publish_test.go
@@ -365,7 +365,7 @@ func TestPublish(t *testing.T) {
 					),
 					HasCampaign: false,
 					CampaignID:  0,
-					Metadata:    []byte("{\"cli\":{\"version\":\"1\"}}"),
+					Metadata:    metadata,
 				},
 			).
 			Return(testutil.NewResponse(&launchtypes.MsgCreateChainResponse{
@@ -481,7 +481,7 @@ func TestPublish(t *testing.T) {
 					),
 					HasCampaign: false,
 					CampaignID:  0,
-					Metadata:    []byte("{\"cli\":{\"version\":\"1\"}}"),
+					Metadata:    metadata,
 				},
 			).
 			Return(testutil.NewResponse(&launchtypes.MsgCreateChainResponse{


### PR DESCRIPTION
Close https://github.com/ignite/cli/issues/2260

- Add field `cli.version` in `metadata`
- Set version to `1`
- Verify version for commands generating the genesis: `chain show genesis` and `chain prepare`
- Set the version automatically in metadata on `publish`

If the version is different
- `chain show genesis` just show a warning since it is the advanced workflow
- `prepare` fails unless `--force` is used